### PR TITLE
Cater to mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/dashboards",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Dashboards Public API",
   "author": {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,7 @@ export interface DashboardDataSourceConfig {
     service: string;
     method: string;
     args?: DashboardDataSourceArgs;
+    mock?: any;
   }[];
 }
 


### PR DESCRIPTION
Will allow mock objects to be applied at config level rather than having to hard code them.  Will enable simple swapping out of mock objects when back end apis are complete.