### PR TITLE
US113373 partner display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/dashboards",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Dashboards Public API",
   "author": {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -82,7 +82,8 @@ export interface DashboardLayoutWidgetConfig {
 }
 
 export interface DashboardMeta {
-  layoutFormat: string;
+  layoutFormat?: string;
+  tags?: string[];
 }
 
 export interface DashboardLayoutConfig {


### PR DESCRIPTION
Added a 'tags' array to the meta.  Allows arbitrary tags to be added against a dashboard to facilitate additional decisions to be made against it.