### PR TITLE
Adding further context_account_id params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/dashboards",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Dashboards Public API",
   "author": {

--- a/src/dashboards-client.ts
+++ b/src/dashboards-client.ts
@@ -152,19 +152,20 @@ class DashboardsClient {
   /**
    * Creates a user dashboard item for the authenticated user and returns it
    */
-  async createOwnDashboardItem(reportRequest: DashboardRequest) {
+  async createOwnDashboardItem(accountId: string, reportRequest: DashboardRequest) {
     const dashboard = await this.alClient.post({
       service_name: this.serviceName,
       version: this.version,
       path: '/user/dashboard_items',
       data: reportRequest,
+      context_account_id: accountId,
     });
     return dashboard as UserDashboardItem;
   }
   /**
    * Get a dashboard item for the authenticated user.
    */
-  async getOwnDashboardItem(dashboardItemId: string, requestQueryParams: {resolve_shared_refs?: boolean} = {}) {
+  async getOwnDashboardItem(accountId: string, dashboardItemId: string, requestQueryParams: {resolve_shared_refs?: boolean} = {}) {
     const item = await this.alClient.get({
       service_name: this.serviceName,
       version: this.version,
@@ -189,23 +190,25 @@ class DashboardsClient {
   /**
    * Update an existing user dashboard item (of the authenticated user) and return it.
    */
-  async updateOwnDashboardItem(dashboardItemId: string, reportRequest: DashboardRequest) {
+  async updateOwnDashboardItem(accountId: string, dashboardItemId: string, reportRequest: DashboardRequest) {
     const dashboard = await this.alClient.set({
       service_name: this.serviceName,
       version: this.version,
       path: `/user/dashboard_items/${dashboardItemId}`,
       data: reportRequest,
+      context_account_id: accountId,
     });
     return dashboard as UserDashboardItem;
   }
   /**
    * Delete a dashboard item for the authenticated user.
    */
-  async deleteOwnDashboardItem(dashboardItemId: string) {
+  async deleteOwnDashboardItem(accountId: string, dashboardItemId: string) {
     const dashboard = await this.alClient.delete({
       service_name: this.serviceName,
       version: this.version,
       path: `/user/dashboard_items/${dashboardItemId}`,
+      context_account_id: accountId,
     });
     return dashboard;
   }

--- a/test/dashboards-client.spec.ts
+++ b/test/dashboards-client.spec.ts
@@ -26,6 +26,7 @@ const sharedDashboardItem: SharedDashboardItem = {
   dashboard: {},
 };
 const sharedDashboardItemId = 'xZ-AA-11-XY-blaa';
+const contextAccountId = '12345';
 
 afterEach(() => {
   sinon.restore();
@@ -242,6 +243,7 @@ describe('Dashboards Client Test Suite:', () => {
   // own
   describe('when creating a dashboard item for the currently authenticated user', () => {
     let stub: sinon.SinonSpy;
+
     beforeEach(() => {
       stub = sinon.stub(DashboardsClient['alClient'], 'post');
     });
@@ -249,13 +251,14 @@ describe('Dashboards Client Test Suite:', () => {
       stub.restore();
     });
     it('should call post() on the ALClient instance to the users dashboard items endpoint with the correct payload', async() => {
-      await DashboardsClient.createOwnDashboardItem(dashboardItemRequest);
+      await DashboardsClient.createOwnDashboardItem(contextAccountId, dashboardItemRequest);
       expect(stub.callCount).to.equal(1);
       const payload = {
         service_name: serviceName,
         version: serviceVersion,
         path: '/user/dashboard_items',
         data: dashboardItemRequest,
+        context_account_id: contextAccountId,
       };
       assert.deepEqual(payload, stub.args[0][0]);
     });
@@ -269,13 +272,14 @@ describe('Dashboards Client Test Suite:', () => {
       stub.restore();
     });
     it('should call get() on the ALClient instance to the users dashboard items endpoint with the correct payload', async() => {
-      await DashboardsClient.getOwnDashboardItem(dashboardItemId);
+      await DashboardsClient.getOwnDashboardItem(contextAccountId, dashboardItemId);
       expect(stub.callCount).to.equal(1);
       const payload = {
         service_name: serviceName,
         version: serviceVersion,
         path: `/user/dashboard_items/${dashboardItemId}`,
         params: {},
+        context_account_id: contextAccountId,
       };
       assert.deepEqual(payload, stub.args[0][0]);
     });
@@ -289,13 +293,14 @@ describe('Dashboards Client Test Suite:', () => {
       stub.restore();
     });
     it('should call set() on the ALClient instance to the users dashboard items endpoint with the correct payload', async() => {
-      await DashboardsClient.updateOwnDashboardItem(dashboardItemId, dashboardItemRequest);
+      await DashboardsClient.updateOwnDashboardItem(contextAccountId, dashboardItemId, dashboardItemRequest);
       expect(stub.callCount).to.equal(1);
       const payload = {
         service_name: serviceName,
         version: serviceVersion,
         path: `/user/dashboard_items/${dashboardItemId}`,
         data: dashboardItemRequest,
+        context_account_id: contextAccountId,
       };
       assert.deepEqual(payload, stub.args[0][0]);
     });
@@ -309,12 +314,13 @@ describe('Dashboards Client Test Suite:', () => {
       stub.restore();
     });
     it('should call delete() on the ALClient instance to the users dashboard items endpoint', async() => {
-      await DashboardsClient.deleteOwnDashboardItem(dashboardItemId);
+      await DashboardsClient.deleteOwnDashboardItem(contextAccountId, dashboardItemId);
       expect(stub.callCount).to.equal(1);
       const payload = {
         service_name: serviceName,
         version: serviceVersion,
         path: `/user/dashboard_items/${dashboardItemId}`,
+        context_account_id: contextAccountId,
       };
       assert.deepEqual(payload, stub.args[0][0]);
     });


### PR DESCRIPTION
Adding further context_account_id params to alClient CRUD methods for user's own dashboard item operations.